### PR TITLE
Remove default settings object

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,7 @@
         "toggleSettingsChanges.settingsToToggle": {
           "scope": "resource",
           "type": "object",
-          "default": {
-            "window.zoomLevel": 2,
-            "editor.fontSize": 22,
-            "terminal.integrated.fontSize": 16,
-            "scm.diffDecorations": "none",
-            "workbench.statusBar.visible": false,
-            "editor.cursorBlinking": "solid",
-            "workbench.activityBar.visible": false
-          },
+          "default": {},
           "description": "An object with the setting name as the object key and the setting value (string, boolean, object, etc.) as the object value."
         }
       }


### PR DESCRIPTION
It seems that any object properties provided in a
default settings value are *merged*, instead of replaced.
This isn't the behavior I expected, or desired in a release.

I'm removing the default settings block for now.

Ticket: https://github.com/tcg/vscode-toggle-settings/issues/10
Ticket: https://stackoverflow.com/questions/58567410/am-i-understanding-this-vs-code-api-behavior-correctly-non-default-object-set